### PR TITLE
Signal store

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -67,7 +67,7 @@
       </ul>
 
       <div class="load-more">
-        @if(store.collection.items().length !== store.collection.count()) {
+        @if(store.hasMoreResults()) {
         <button (click)="store.loadMore()">Afficher plus</button>
         }
       </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -12,12 +12,12 @@
       </label>
       <div class="collapsible-body">
         <ul class="inline">
-          @for(lang of languages$ | async; track lang) {
+          @for(lang of store.languages(); track lang) {
           <li>
             <button
               class="btn-small"
-              [class.btn-primary]="lang === selectedLang"
-              (click)="selectedLang = lang"
+              [class.btn-primary]="lang === store.selectedLang()"
+              (click)="store.setLang(lang)"
             >
               {{ lang }}
             </button>
@@ -35,16 +35,18 @@
         type="text"
         id="pokeSearch"
         placeholder="Search..."
+        [ngModel]="store.search()"
+        (ngModelChange)="store.setSearch($event)"
       />
     </div>
 
     <ul class="type-list">
-      @for(type of pokemonTypes$ | async; track type) {
+      @for(type of store.types(); track type) {
       <li>
         <button
           class="btn-small"
-          [class.btn-primary]="type.id === selectedType?.id"
-          (click)="selectedType = type.id === selectedType?.id ? null : type"
+          [class.btn-primary]="type.id === store.selectedTypeId()"
+          (click)="store.setTypeId(type.id)"
         >
           {{ type.name }}
         </button>
@@ -52,12 +54,11 @@
       }
     </ul>
 
-    @if(pokemons$ | async; as pokemons) {
     <div>
-      <h2>Pokémons ({{ pokemons.count }})</h2>
+      <h2>Pokémons ({{ store.collection.count() }})</h2>
 
       <ul class="pokemon-list">
-        @for(pokemon of pokemons.items; track pokemon.id) {
+        @for(pokemon of store.collection.items(); track pokemon.id) {
         <li>
           <img [src]="pokemon.image" [alt]="pokemon.name + '\'s picture'" />
           {{ pokemon.name }}
@@ -66,11 +67,10 @@
       </ul>
 
       <div class="load-more">
-        @if(pokemons.items.length !== pokemons.count) {
-        <button>Afficher plus</button>
+        @if(store.collection.items().length !== store.collection.count()) {
+        <button (click)="store.loadMore()">Afficher plus</button>
         }
       </div>
     </div>
-    }
   </main>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,22 +1,15 @@
-import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import { PokemonType } from './poke.models';
-import { PokeService } from './poke.service';
+import { FormsModule } from '@angular/forms';
+import { PokeStore } from './app.store';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [AsyncPipe],
+  imports: [FormsModule],
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
+  providers: [PokeStore],
 })
 export class AppComponent {
-  #pokeService = inject(PokeService);
-
-  pokemonTypes$ = this.#pokeService.getTypes();
-  pokemons$ = this.#pokeService.getPokemons();
-  languages$ = this.#pokeService.getLanguages();
-
-  selectedLang: string = 'en';
-  selectedType: PokemonType | null = null;
+  store = inject(PokeStore);
 }

--- a/src/app/app.store.ts
+++ b/src/app/app.store.ts
@@ -1,0 +1,80 @@
+
+import { rxMethod, selectSignal, signalStore, withHooks, withMethods, withSignals, withState } from '@ngrx/signal-store';
+import { debounceTime, pipe, switchMap, tap } from 'rxjs';
+import { PokemonCollection, PokemonType } from './poke.models';
+import { PokeService, PokemonQuery } from './poke.service';
+import { signalPipe, stripUndefinedValues } from './utils';
+import { inject } from '@angular/core';
+
+type PokeState = {
+  types: PokemonType[];
+  collection: PokemonCollection;
+  languages: string[];
+  selectedLang: string;
+  page: number;
+  selectedTypeId: number | undefined;
+  search: string;
+}
+
+export const PokeStore = signalStore(
+  withState<PokeState>({
+    types: [],
+    collection: { count: 0, items: [] },
+    languages: [],
+    selectedLang: 'en',
+    page: 1,
+    search: '',
+    selectedTypeId: undefined,
+  }),
+  withSignals((store) => ({
+    pokemonQuery: selectSignal(
+      store.page,
+      store.selectedTypeId,
+      signalPipe(store.search, debounceTime(300), { initialValue: '' }),
+      store.selectedLang,
+      (page, typeId, search, lang): PokemonQuery => stripUndefinedValues({ page, typeId, search, lang }),
+    ),
+  })),
+  withMethods(({ $update, page, selectedTypeId }) => {
+    const pokeService = inject(PokeService);
+
+    return ({
+      loadTypes: rxMethod<string>(pipe(
+        switchMap(lang => pokeService.getTypes({ lang })),
+        tap(types => $update({ types })),
+      )),
+      loadLanguages: rxMethod<void>(pipe(
+        switchMap(() => pokeService.getLanguages()),
+        tap(languages => $update({ languages })),
+      )),
+      loadPokemons: rxMethod<PokemonQuery>(pipe(
+        switchMap(query => pokeService.getPokemons(query)),
+        tap(collection => $update(s => ({
+          collection: page() === 1 ? collection : {
+            count: collection.count,
+            items: [...s.collection.items, ...collection.items],
+          },
+        }))),
+      )),
+      setLang(selectedLang: string) {
+        $update({ selectedLang, page: 1 });
+      },
+      setTypeId(typeId: number | undefined) {
+        $update({ selectedTypeId: typeId === selectedTypeId() ? undefined : typeId, page: 1 });
+      },
+      setSearch(search: string) {
+        $update({ search, page: 1 });
+      },
+      loadMore() {
+        $update({ page: page() + 1 });
+      },
+    });
+  }),
+  withHooks({
+    onInit(store) {
+      store.loadLanguages();
+      store.loadTypes(store.selectedLang);
+      store.loadPokemons(store.pokemonQuery);
+    },
+  })
+);

--- a/src/app/app.store.ts
+++ b/src/app/app.store.ts
@@ -2,23 +2,22 @@
 import { inject } from '@angular/core';
 import { rxMethod, selectSignal, signalStore, withHooks, withMethods, withSignals, withState } from '@ngrx/signal-store';
 import { debounceTime, pipe, switchMap, tap } from 'rxjs';
-import { setLang, setPokemonTypeId, withLanguageFeature, withTypesFeature } from './features';
+import { resetPage, setLang, setPokemonTypeId, withLanguageFeature, withPaginationFeature, withTypesFeature } from './features';
 import { PokemonCollection } from './poke.models';
 import { PokeService, PokemonQuery } from './poke.service';
 import { signalPipe, stripUndefinedValues } from './utils';
 
 type PokeState = {
   collection: PokemonCollection;
-  page: number;
   search: string;
 }
 
 export const PokeStore = signalStore(
   withLanguageFeature(),
   withTypesFeature(),
+  withPaginationFeature(),
   withState<PokeState>({
     collection: { count: 0, items: [] },
-    page: 1,
     search: '',
   }),
   withSignals((store) => ({
@@ -44,16 +43,13 @@ export const PokeStore = signalStore(
         }))),
       )),
       setLang(selectedLang: string) {
-        $update(setLang(selectedLang), { page: 1 });
+        $update(setLang(selectedLang), resetPage());
       },
       setTypeId(typeId: number | undefined) {
-        $update(setPokemonTypeId(typeId), { page: 1 });
+        $update(setPokemonTypeId(typeId), resetPage());
       },
       setSearch(search: string) {
-        $update({ search, page: 1 });
-      },
-      loadMore() {
-        $update({ page: page() + 1 });
+        $update({ search }, resetPage());
       },
     });
   }),

--- a/src/app/features/collection.feature.ts
+++ b/src/app/features/collection.feature.ts
@@ -1,0 +1,38 @@
+import { computed } from '@angular/core';
+import { SignalStateUpdater, signalStoreFeature, withSignals, withState } from '@ngrx/signal-store';
+
+export type Collection<T> = {
+  items: T[];
+  count: number;
+};
+
+export type CollectionFeatureState<T> = {
+  collection: Collection<T>;
+};
+
+export function withCollectionFeature<T>() {
+  return signalStoreFeature(
+    withState<CollectionFeatureState<T>>({
+      collection: {
+        items: [],
+        count: 0,
+      },
+    }),
+    withSignals(({ collection }) => ({
+      hasMoreResults: computed(() => collection.items().length < collection.count()),
+    })),
+  );
+}
+
+export function mergeCollection<T>(collection: Collection<T>): SignalStateUpdater<CollectionFeatureState<T>> {
+  return state => ({
+    collection: {
+      items: [...state.collection.items, ...collection.items],
+      count: state.collection.count,
+    },
+  });
+}
+
+export function setCollection<T>(collection: Collection<T>): SignalStateUpdater<CollectionFeatureState<T>> {
+  return { collection };
+}

--- a/src/app/features/index.ts
+++ b/src/app/features/index.ts
@@ -1,3 +1,4 @@
+export * from './collection.feature';
 export * from './language.feature';
 export * from './paging.feature';
 export * from './types.feature';

--- a/src/app/features/index.ts
+++ b/src/app/features/index.ts
@@ -1,0 +1,1 @@
+export * from './language.feature';

--- a/src/app/features/index.ts
+++ b/src/app/features/index.ts
@@ -1,1 +1,2 @@
 export * from './language.feature';
+export * from './types.feature';

--- a/src/app/features/index.ts
+++ b/src/app/features/index.ts
@@ -1,2 +1,3 @@
 export * from './language.feature';
+export * from './paging.feature';
 export * from './types.feature';

--- a/src/app/features/language.feature.ts
+++ b/src/app/features/language.feature.ts
@@ -1,0 +1,30 @@
+import { inject } from '@angular/core';
+import { signalStoreFeature, withState, withMethods, rxMethod, withHooks, SignalStateUpdater } from '@ngrx/signal-store';
+import { pipe, switchMap, tap } from 'rxjs';
+import { PokeService } from '../poke.service';
+
+export type LanguageFeatureState = {
+  languages: string[];
+  selectedLang: string;
+}
+
+export function withLanguageFeature() {
+  return signalStoreFeature(
+    withState<LanguageFeatureState>({ languages: [], selectedLang: 'en' }),
+    withMethods(({ $update }, pokeService = inject(PokeService)) => ({
+      loadLanguages: rxMethod<void>(pipe(
+        switchMap(() => pokeService.getLanguages()),
+        tap(languages => $update({ languages })),
+      )),
+    })),
+    withHooks({
+      onInit(store) {
+        store.loadLanguages();
+      },
+    }),
+  );
+}
+
+export function setLang(selectedLang: string): SignalStateUpdater<LanguageFeatureState> {
+  return { selectedLang };
+}

--- a/src/app/features/paging.feature.ts
+++ b/src/app/features/paging.feature.ts
@@ -1,0 +1,20 @@
+import { SignalStateUpdater, signalStoreFeature, withMethods, withState } from '@ngrx/signal-store';
+
+export type PaginationFeatureState = {
+  page: number;
+};
+
+export function withPaginationFeature() {
+  return signalStoreFeature(
+    withState<{ page: number }>({ page: 1 }),
+    withMethods(({ $update, page }) => ({
+      loadMore() {
+        $update({ page: page() + 1 });
+      },
+    })),
+  )
+}
+
+export function resetPage(): SignalStateUpdater<PaginationFeatureState> {
+  return { page: 1 };
+}

--- a/src/app/features/types.feature.ts
+++ b/src/app/features/types.feature.ts
@@ -1,0 +1,35 @@
+import { inject } from '@angular/core';
+import { SignalStateUpdater, rxMethod, signalStoreFeature, type, withHooks, withMethods, withState } from '@ngrx/signal-store';
+import { pipe, switchMap, tap } from 'rxjs';
+import { PokemonType } from '../poke.models';
+import { PokeService } from '../poke.service';
+
+export type TypesFeatureState = {
+  types: PokemonType[];
+  selectedTypeId: number | undefined;
+}
+
+export function withTypesFeature() {
+  return signalStoreFeature(
+    {
+      // selectedLang should be available in the state
+      state: type<{ selectedLang: string }>(),
+    },
+    withState<TypesFeatureState>({ types: [], selectedTypeId: undefined }),
+    withMethods(({ $update }, pokeService = inject(PokeService)) => ({
+      loadTypes: rxMethod<string>(pipe(
+        switchMap(lang => pokeService.getTypes({ lang })),
+        tap(types => $update({ types })),
+      )),
+    })),
+    withHooks({
+      onInit(store) {
+        store.loadTypes(store.selectedLang);
+      },
+    }),
+  );
+}
+
+export function setPokemonTypeId(selectedTypeId: number | undefined): SignalStateUpdater<TypesFeatureState> {
+  return s => ({ selectedTypeId: s.selectedTypeId === selectedTypeId ? undefined : selectedTypeId });
+}

--- a/src/app/poke.models.ts
+++ b/src/app/poke.models.ts
@@ -1,16 +1,16 @@
-export interface PokemonCollection {
+export type PokemonCollection = {
   count: number
   items: Pokemon[];
 }
 
-export interface Pokemon {
+export type Pokemon = {
   id: number;
   name: string;
   description: string;
   image: string;
 }
 
-export interface PokemonType {
+export type PokemonType = {
   id: number;
   name: string;
 }

--- a/src/app/poke.service.ts
+++ b/src/app/poke.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable, inject } from "@angular/core";
 import { PokemonCollection, PokemonType } from "./poke.models";
 
-export interface PokemonQuery {
+export type PokemonQuery = {
   limit?: number;
   page?: number;
   typeId?: number;
@@ -10,7 +10,7 @@ export interface PokemonQuery {
   search?: string;
 }
 
-export interface PokemonTypeQuery {
+export type PokemonTypeQuery = {
   lang?: string;
 }
 
@@ -20,9 +20,9 @@ export interface PokemonTypeQuery {
 export class PokeService {
   #httpClient = inject(HttpClient);
 
-  getTypes = (query: PokemonTypeQuery = {}) => this.#httpClient.get<PokemonType[]>('/api/types', { params: { ...query } });
+  getTypes = (query: PokemonTypeQuery = {}) => this.#httpClient.get<PokemonType[]>('/api/types', { params: query });
 
-  getPokemons = (query: PokemonQuery = {}) => this.#httpClient.get<PokemonCollection>('/api/pokemons', { params: { ...query } });
+  getPokemons = (query: PokemonQuery = {}) => this.#httpClient.get<PokemonCollection>('/api/pokemons', { params: query });
 
   getLanguages = () => this.#httpClient.get<string[]>('/api/languages');
 }

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,6 +1,6 @@
 import { Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { OperatorFunction } from 'rxjs';
+import { OperatorFunction, merge } from 'rxjs';
 
 // type Typify<T> = {
 //   [K in keyof T]: T[K] extends object ? Typify<T[K]> : T[K];
@@ -29,4 +29,10 @@ export function stripUndefinedValues<T extends Record<string, any>>(obj: T): Par
   }
 
   return result;
+}
+
+export type MergeSignalsResult<T extends ReadonlyArray<Signal<unknown>>> = T extends ReadonlyArray<Signal<infer R>> ? Signal<R> : never;
+
+export function mergeSignals<T extends ReadonlyArray<Signal<unknown>>>(...signals: T): MergeSignalsResult<T> {
+  return toSignal(merge(...signals.map(s => toObservable(s)))) as MergeSignalsResult<T>;
 }

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,0 +1,32 @@
+import { Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { OperatorFunction } from 'rxjs';
+
+// type Typify<T> = {
+//   [K in keyof T]: T[K] extends object ? Typify<T[K]> : T[K];
+// }
+
+export function signalPipe<T, R>(
+  signal: Signal<T>,
+  operator: OperatorFunction<T, R>,
+  options: { requiredSync?: true } | { initialValue: R } = { requiredSync: true },
+): Signal<R> {
+  const source$ = toObservable(signal);
+  const result$ = source$.pipe(operator);
+
+  return 'initialValue' in options
+    ? toSignal(result$, { initialValue: options.initialValue })
+    : toSignal(result$, { requireSync: true });
+}
+
+export function stripUndefinedValues<T extends Record<string, any>>(obj: T): Partial<T> {
+  const result: Partial<T> = {};
+
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Une première implémentation avec un signal store est disponible [sur ce commit](https://github.com/GuillaumeNury/AtelierSignalState/commit/e8242de2cabfa9398af232bdfbb5ed52c52a7350).

Je suis ensuite allé plus loin en découpant mon Store en fonction des différentes fonctionnalités grâce à `signalStoreFeature`. On peut ainsi travailler sur chaque aspect et ensuite combiner le tout pour générer le store.

J'ai poussé volontairement loin le découpage, la simplicité du store ne méritait probablement pas tant ! Il est possible de lire commit par commit pour voir comment ça marche.